### PR TITLE
Maybe: Add static const object none

### DIFF
--- a/neither/include/maybe.hpp
+++ b/neither/include/maybe.hpp
@@ -4,6 +4,7 @@
 #include <memory>
 #include <cassert>
 #include <cstddef>
+#include <type_traits>
 #include <neither/traits.hpp>
 
 namespace neither {
@@ -106,18 +107,33 @@ auto maybe(T value) -> Maybe<T> { return {value}; }
 template <typename T = void>
 auto maybe() -> Maybe<T> { return {}; }
 
+namespace {
+
+    template<typename T, typename std::enable_if_t<!std::is_void<T>::value>* = nullptr>
+    bool equal(Maybe<T> const &a, Maybe<T> const &b) {
+        if (a.hasValue) {
+            return b.hasValue && a.value == b.value;
+        }
+        return !b.hasValue;
+    }
+
+    template <typename T, typename std::enable_if_t<std::is_void<T>::value>* = nullptr>
+    bool equal(Maybe<T> const&, Maybe<T> const&) {
+        return true;
+    }
+}
+
 template <typename T>
 bool operator == (Maybe<T> const& a, Maybe<T> const& b) {
-  if (a.hasValue) {
-    return b.hasValue && a.value == b.value;
-  }
-  return !b.hasValue;
+  return equal(a, b);
 }
 
 template <typename T>
 bool operator != (Maybe<T> const& a, Maybe<T> const& b) {
   return !(a == b);
 }
+
+static const auto none = maybe();
 
 }
 

--- a/neither/tests/maybe.cpp
+++ b/neither/tests/maybe.cpp
@@ -55,7 +55,7 @@ TEST(neither, maybe_comparison) {
 }
 
 TEST(neither, maybe_size) {
-  
+
   auto none = maybe<int>();
   auto some = maybe<int>(1);
 
@@ -64,10 +64,18 @@ TEST(neither, maybe_size) {
 }
 
 TEST(neither, maybe_empty) {
-  
+
   auto none = maybe<int>();
   auto some = maybe<int>(1);
 
   EXPECT_TRUE(none.empty());
   EXPECT_FALSE(some.empty());
+}
+
+TEST(neither, maybe_none) {
+  auto none1 = none;
+  auto none2 = none;
+
+  EXPECT_TRUE(none1 == none2);
+  EXPECT_FALSE(none1 != none2);
 }


### PR DESCRIPTION
That is an instance of type Maybe<void>, used to represent the absence
of a value.

Additionally, added support for operator== and operator!= for
Maybe<void>, hence none, with the semantics:

Maybe<void> x;
Maybe<void> y;

x == y => true
x != y => false

Given that it doesn't hold a value.

Therefore, none will be always equal to itself.