### PR TITLE
Maybe: Mark hasValue as deprecated

### DIFF
--- a/neither/include/maybe.hpp
+++ b/neither/include/maybe.hpp
@@ -111,10 +111,10 @@ namespace {
 
     template<typename T, typename std::enable_if_t<!std::is_void<T>::value>* = nullptr>
     bool equal(Maybe<T> const &a, Maybe<T> const &b) {
-        if (a.hasValue) {
-            return b.hasValue && a.value == b.value;
+        if (!a.empty()) {
+            return !b.empty() && a.value == b.value;
         }
-        return !b.hasValue;
+        return b.empty();
     }
 
     template <typename T, typename std::enable_if_t<std::is_void<T>::value>* = nullptr>

--- a/neither/include/maybe.hpp
+++ b/neither/include/maybe.hpp
@@ -21,6 +21,7 @@ template <class T> struct Maybe {
     T value;
   };
 
+  [[deprecated("hasValue shall be made private in the future. Use !empty() instead")]]
   bool const hasValue;
 
   constexpr Maybe() : hasValue{false} {}

--- a/neither/tests/lift.cpp
+++ b/neither/tests/lift.cpp
@@ -18,6 +18,6 @@ TEST(neither, lift_maybes) {
   );
 
 
-  ASSERT_TRUE(sum1.hasValue && sum1.value == 12);
-  ASSERT_TRUE(!sum2.hasValue);
+  ASSERT_TRUE(!sum1.empty() && sum1.value == 12);
+  ASSERT_TRUE(sum2.empty());
 }

--- a/neither/tests/try.cpp
+++ b/neither/tests/try.cpp
@@ -13,8 +13,8 @@ TEST(neither, try_and_fail) {
   auto result = e.join([](auto x) { return x; }, [](auto x) { return 1; });
 
   ASSERT_TRUE(result == 42);
-  ASSERT_TRUE(e.left().hasValue);
-  ASSERT_TRUE(!e.right().hasValue);
+  ASSERT_TRUE(!e.left().empty());
+  ASSERT_TRUE(e.right().empty());
 }
 
 TEST(neither, try_and_succeed) {
@@ -26,6 +26,6 @@ TEST(neither, try_and_succeed) {
   auto result = e.join([](auto x) { return 1; }, [](auto x) { return x; });
 
   ASSERT_TRUE(result == 42);
-  ASSERT_TRUE(!e.left().hasValue);
-  ASSERT_TRUE(e.right().hasValue);
+  ASSERT_TRUE(e.left().empty());
+  ASSERT_TRUE(!e.right().empty());
 }

--- a/neither/tests/try.cpp
+++ b/neither/tests/try.cpp
@@ -17,7 +17,7 @@ TEST(neither, try_and_fail) {
   ASSERT_TRUE(!e.right().hasValue);
 }
 
-TEST(neither, try_and_suceed) {
+TEST(neither, try_and_succeed) {
 
   using namespace neither;
 


### PR DESCRIPTION
That is a member variable and shouldn't be exposed to the API, because we might want to change it in the future, without breaking clients.

Instead of hasValue, clients shall use !empty().